### PR TITLE
Bugfix for graph PGD class - test failing

### DIFF
--- a/deeprobust/graph/global_attack/topology_attack.py
+++ b/deeprobust/graph/global_attack/topology_attack.py
@@ -77,7 +77,7 @@ class PGDAttack(BaseAttack):
         best_loss = -1000
         victim_model = self.surrogate
         with torch.no_grad():
-            s = self.adj_changes.cpu().numpy()
+            s = self.adj_changes.cpu().detach().numpy()
             for i in range(K):
                 sampled = np.random.binomial(1, s)
 


### PR DESCRIPTION
Thanks for making this library! 

I'm using PyTorch 1.5.0 (cpu version). The test `examples/graph/test_pgd.py` was failing with the following error:

```
Traceback (most recent call last):
  File "examples/graph/test_pgd.py", line 95, in <module>
    main()
  File "examples/graph/test_pgd.py", line 83, in main
    model.attack(features, adj, labels, idx_train, perturbations)
  File "/anaconda3/lib/python3.7/site-packages/deeprobust/graph/global_attack/topology_attack.py", line 72, in attack
    self.random_sample(ori_adj, ori_features, labels, idx_train, perturbations)
  File "/anaconda3/lib/python3.7/site-packages/deeprobust/graph/global_attack/topology_attack.py", line 80, in random_sample
    s = self.adj_changes.cpu().numpy()
RuntimeError: Can't call numpy() on Variable that requires grad. Use var.detach().numpy() instead.
```

I changed line 80 from `s = self.adj_changes.cpu().numpy()` to `s = self.adj_changes.cpu().detach().numpy()` and now the test passes