### PR TITLE
Tidy imports and module docstrings graph global attacks

### DIFF
--- a/deeprobust/graph/global_attack/__init__.py
+++ b/deeprobust/graph/global_attack/__init__.py
@@ -2,8 +2,6 @@ from .base_attack import BaseAttack
 from .dice import DICE
 from .mettack import MetaApprox, Metattack
 from .random import Random
-from .topology_attack import PGDAttack
-from .topology_attack import MinMax
+from .topology_attack import MinMax, PGDAttack
 
 __all__ = ['BaseAttack', 'DICE', 'MetaApprox', 'Metattack', 'Random', 'MinMax', 'PGDAttack']
-

--- a/deeprobust/graph/global_attack/base_attack.py
+++ b/deeprobust/graph/global_attack/base_attack.py
@@ -1,9 +1,12 @@
+import os.path as osp
+
+import numpy as np
+import scipy.sparse as sp
 import torch
 from torch.nn.modules.module import Module
-import scipy.sparse as sp
+
 from deeprobust.graph import utils
-import os.path as osp
-import numpy as np
+
 
 class BaseAttack(Module):
 
@@ -56,5 +59,3 @@ class BaseAttack(Module):
             sp.save_npz(osp.join(root, name), sparse_features)
         else:
             sp.save_npz(osp.join(root, name), modified_features)
-
-

--- a/deeprobust/graph/global_attack/dice.py
+++ b/deeprobust/graph/global_attack/dice.py
@@ -1,11 +1,5 @@
-import torch
 from deeprobust.graph.global_attack import BaseAttack
-from torch.nn.parameter import Parameter
-from copy import deepcopy
-from deeprobust.graph import utils
-import torch.nn.functional as F
 import numpy as np
-from copy import deepcopy
 import scipy.sparse as sp
 import random
 

--- a/deeprobust/graph/global_attack/dice.py
+++ b/deeprobust/graph/global_attack/dice.py
@@ -1,7 +1,10 @@
-from deeprobust.graph.global_attack import BaseAttack
+import random
+
 import numpy as np
 import scipy.sparse as sp
-import random
+
+from deeprobust.graph.global_attack import BaseAttack
+
 
 class DICE(BaseAttack):
 
@@ -82,4 +85,3 @@ class DICE(BaseAttack):
         '''
         itr = self.sample_forever(adj, exclude=exclude)
         return [next(itr) for _ in range(n)]
-

--- a/deeprobust/graph/global_attack/ig_attack.py
+++ b/deeprobust/graph/global_attack/ig_attack.py
@@ -5,15 +5,16 @@
         https://github.com/KaidiXu/GCN_ADV_Train
 '''
 
-import torch
-from deeprobust.graph.global_attack import BaseAttack
-from torch.nn.parameter import Parameter
-from deeprobust.graph import utils
-
-from torch.nn import functional as F
 import numpy as np
-from tqdm import tqdm
 import scipy.sparse as sp
+import torch
+from torch.nn import functional as F
+from torch.nn.parameter import Parameter
+from tqdm import tqdm
+
+from deeprobust.graph import utils
+from deeprobust.graph.global_attack import BaseAttack
+
 
 class IGAttack(BaseAttack):
 
@@ -154,4 +155,3 @@ class IGAttack(BaseAttack):
 
     def get_modified_features(self, ori_features):
         return ori_features + self.feature_changes
-

--- a/deeprobust/graph/global_attack/ig_attack.py
+++ b/deeprobust/graph/global_attack/ig_attack.py
@@ -1,9 +1,9 @@
-'''
+"""
     Topology Attack and Defense for Graph Neural Networks: An Optimization Perspective
         https://arxiv.org/pdf/1906.04214.pdf
     Tensorflow Implementation:
         https://github.com/KaidiXu/GCN_ADV_Train
-'''
+"""
 
 import numpy as np
 import scipy.sparse as sp

--- a/deeprobust/graph/global_attack/ig_attack.py
+++ b/deeprobust/graph/global_attack/ig_attack.py
@@ -6,20 +6,13 @@
 '''
 
 import torch
-import torch.multiprocessing as mp
 from deeprobust.graph.global_attack import BaseAttack
 from torch.nn.parameter import Parameter
 from deeprobust.graph import utils
-import torch.nn.functional as F
-import numpy as np
-import scipy.sparse as sp
 
-from torch import optim
 from torch.nn import functional as F
-from torch.nn.modules.module import Module
 import numpy as np
 from tqdm import tqdm
-import math
 import scipy.sparse as sp
 
 class IGAttack(BaseAttack):

--- a/deeprobust/graph/global_attack/mettack.py
+++ b/deeprobust/graph/global_attack/mettack.py
@@ -5,17 +5,19 @@
         https://github.com/danielzuegner/gnn-meta-attack
 '''
 
-import torch
-from deeprobust.graph.global_attack import BaseAttack
-from torch.nn.parameter import Parameter
-from deeprobust.graph import utils
+import math
 
+import numpy as np
+import scipy.sparse as sp
+import torch
 from torch import optim
 from torch.nn import functional as F
-import numpy as np
+from torch.nn.parameter import Parameter
 from tqdm import tqdm
-import math
-import scipy.sparse as sp
+
+from deeprobust.graph import utils
+from deeprobust.graph.global_attack import BaseAttack
+
 
 class BaseMeta(BaseAttack):
 
@@ -417,5 +419,3 @@ class MetaApprox(BaseMeta):
             self.modified_adj = self.get_modified_adj(ori_adj).detach()
         if self.attack_features:
             self.modified_features = self.get_modified_features(ori_features).detach()
-
-

--- a/deeprobust/graph/global_attack/mettack.py
+++ b/deeprobust/graph/global_attack/mettack.py
@@ -9,13 +9,9 @@ import torch
 from deeprobust.graph.global_attack import BaseAttack
 from torch.nn.parameter import Parameter
 from deeprobust.graph import utils
-import torch.nn.functional as F
-import numpy as np
-import scipy.sparse as sp
 
 from torch import optim
 from torch.nn import functional as F
-from torch.nn.modules.module import Module
 import numpy as np
 from tqdm import tqdm
 import math

--- a/deeprobust/graph/global_attack/mettack.py
+++ b/deeprobust/graph/global_attack/mettack.py
@@ -1,9 +1,9 @@
-'''
+"""
     Adversarial Attacks on Graph Neural Networks via Meta Learning. ICLR 2019
         https://openreview.net/pdf?id=Bylnx209YX
     Author Tensorflow implementation:
         https://github.com/danielzuegner/gnn-meta-attack
-'''
+"""
 
 import math
 

--- a/deeprobust/graph/global_attack/nipa.py
+++ b/deeprobust/graph/global_attack/nipa.py
@@ -2,18 +2,13 @@
 Still on testing stage. Haven't reproduced the performance yet.
 '''
 import os
-import sys
 import os.path as osp
 import numpy as np
 import torch
-import networkx as nx
 import random
-from torch.nn.parameter import Parameter
-import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 from tqdm import tqdm
-from copy import deepcopy
 from deeprobust.graph.rl.nipa_q_net_node import QNetNode, NStepQNetNode, node_greedy_actions
 from deeprobust.graph.rl.nstep_replay_mem import NstepReplayMem
 from deeprobust.graph.utils import loss_acc

--- a/deeprobust/graph/global_attack/nipa.py
+++ b/deeprobust/graph/global_attack/nipa.py
@@ -3,16 +3,20 @@ Still on testing stage. Haven't reproduced the performance yet.
 '''
 import os
 import os.path as osp
+import random
+from itertools import count
+
 import numpy as np
 import torch
-import random
 import torch.nn.functional as F
 import torch.optim as optim
 from tqdm import tqdm
-from deeprobust.graph.rl.nipa_q_net_node import QNetNode, NStepQNetNode, node_greedy_actions
+
+from deeprobust.graph.rl.nipa_q_net_node import (NStepQNetNode, QNetNode,
+                                                 node_greedy_actions)
 from deeprobust.graph.rl.nstep_replay_mem import NstepReplayMem
 from deeprobust.graph.utils import loss_acc
-from itertools import count
+
 
 class NIPA(object):
 
@@ -230,4 +234,3 @@ class NIPA(object):
 
         if t == 2:
             return self.possible_labels.repeat((len(list_st), 1))
-

--- a/deeprobust/graph/global_attack/nipa.py
+++ b/deeprobust/graph/global_attack/nipa.py
@@ -1,6 +1,7 @@
-'''
+"""
 Still on testing stage. Haven't reproduced the performance yet.
-'''
+"""
+
 import os
 import os.path as osp
 import random

--- a/deeprobust/graph/global_attack/random.py
+++ b/deeprobust/graph/global_attack/random.py
@@ -1,12 +1,6 @@
-import torch
 from deeprobust.graph.global_attack import BaseAttack
-from torch.nn.parameter import Parameter
-from copy import deepcopy
-from deeprobust.graph import utils
-import torch.nn.functional as F
 import numpy as np
 import random
-from copy import deepcopy
 
 
 class Random(BaseAttack):

--- a/deeprobust/graph/global_attack/random.py
+++ b/deeprobust/graph/global_attack/random.py
@@ -1,6 +1,8 @@
-from deeprobust.graph.global_attack import BaseAttack
-import numpy as np
 import random
+
+import numpy as np
+
+from deeprobust.graph.global_attack import BaseAttack
 
 
 class Random(BaseAttack):
@@ -96,4 +98,3 @@ class Random(BaseAttack):
                 yield t
                 exclude.add(t)
                 exclude.add((t[1], t[0]))
-

--- a/deeprobust/graph/global_attack/topology_attack.py
+++ b/deeprobust/graph/global_attack/topology_attack.py
@@ -5,16 +5,17 @@
         https://github.com/KaidiXu/GCN_ADV_Train
 '''
 
+import numpy as np
+import scipy.sparse as sp
 import torch
-from deeprobust.graph.global_attack import BaseAttack
-from torch.nn.parameter import Parameter
-from deeprobust.graph import utils
-
 from torch import optim
 from torch.nn import functional as F
-import numpy as np
+from torch.nn.parameter import Parameter
 from tqdm import tqdm
-import scipy.sparse as sp
+
+from deeprobust.graph import utils
+from deeprobust.graph.global_attack import BaseAttack
+
 
 class PGDAttack(BaseAttack):
 
@@ -198,4 +199,3 @@ class MinMax(PGDAttack):
 
         self.random_sample(ori_adj, ori_features, labels, idx_train, perturbations)
         self.modified_adj = self.get_modified_adj(ori_adj).detach()
-

--- a/deeprobust/graph/global_attack/topology_attack.py
+++ b/deeprobust/graph/global_attack/topology_attack.py
@@ -9,16 +9,11 @@ import torch
 from deeprobust.graph.global_attack import BaseAttack
 from torch.nn.parameter import Parameter
 from deeprobust.graph import utils
-import torch.nn.functional as F
-import numpy as np
-import scipy.sparse as sp
 
 from torch import optim
 from torch.nn import functional as F
-from torch.nn.modules.module import Module
 import numpy as np
 from tqdm import tqdm
-import math
 import scipy.sparse as sp
 
 class PGDAttack(BaseAttack):

--- a/deeprobust/graph/global_attack/topology_attack.py
+++ b/deeprobust/graph/global_attack/topology_attack.py
@@ -1,9 +1,9 @@
-'''
+"""
     Topology Attack and Defense for Graph Neural Networks: An Optimization Perspective
         https://arxiv.org/pdf/1906.04214.pdf
     Tensorflow Implementation:
         https://github.com/KaidiXu/GCN_ADV_Train
-'''
+"""
 
 import numpy as np
 import scipy.sparse as sp


### PR DESCRIPTION
I did some organising of the docstring and imports for the global attacks modules. I removed unused and duplicate imports and organised them according to [PEP8](https://www.python.org/dev/peps/pep-0008/#imports).  I also changed the module docstrings to triple quotes as [per PEP 257](https://www.python.org/dev/peps/pep-0257/#specification)