### PR TITLE
I22 refactor attack method

### DIFF
--- a/deeprobust/graph/global_attack/base_attack.py
+++ b/deeprobust/graph/global_attack/base_attack.py
@@ -25,7 +25,21 @@ class BaseAttack(Module):
             self.nfeat = model.nfeat
             self.hidden_sizes = model.hidden_sizes
 
-    def attack(self):
+    def attack(self, ori_adj, n_perturbations, **kwargs):
+        """Generate an adversarial example.
+
+        Parameters
+        ----------
+        ori_adj : scipy.sparse.csr_matrix
+            Original (unperturbed) adjacency matrix.
+        n_perturbations : int
+            Number of edge removals/additions.
+
+        Returns
+        -------
+        None.
+
+        """
         pass
 
     def check_adj(self, adj):

--- a/deeprobust/graph/global_attack/dice.py
+++ b/deeprobust/graph/global_attack/dice.py
@@ -19,20 +19,20 @@ class DICE(BaseAttack):
 
         assert not self.attack_features, 'DICE does NOT support attacking features'
 
-    def attack(self, adj, labels, n_perturbations):
+    def attack(self, ori_adj, labels, n_perturbations, **kwargs):
         """
         Delete internally, connect externally. This baseline has all true class labels
         (train and test) available.
         """
-        # adj: sp.csr_matrix
+        # ori_adj: sp.csr_matrix
 
         print('number of pertubations: %s' % n_perturbations)
-        modified_adj = adj.tolil()
+        modified_adj = ori_adj.tolil()
 
         remove_or_insert = np.random.choice(2, n_perturbations)
         n_remove = sum(remove_or_insert)
 
-        nonzero = set(zip(*adj.nonzero()))
+        nonzero = set(zip(*ori_adj.nonzero()))
         indices = sp.triu(modified_adj).nonzero()
         possible_indices = [x for x in zip(indices[0], indices[1])
                             if labels[x[0]] == labels[x[1]]]
@@ -53,8 +53,8 @@ class DICE(BaseAttack):
         # sample edges to add
         for i in range(n_insert):
             # select a node
-            node1 = np.random.randint(adj.shape[0])
-            possible_nodes = [x for x in range(adj.shape[0])
+            node1 = np.random.randint(ori_adj.shape[0])
+            possible_nodes = [x for x in range(ori_adj.shape[0])
                               if labels[x] != labels[node1] and modified_adj[x, node1] == 0]
             # select another node
             node2 = possible_nodes[np.random.randint(len(possible_nodes))]

--- a/deeprobust/graph/global_attack/ig_attack.py
+++ b/deeprobust/graph/global_attack/ig_attack.py
@@ -37,7 +37,7 @@ class IGAttack(BaseAttack):
             self.feature_changes = Parameter(torch.FloatTensor(feature_shape))
             self.feature_changes.data.fill_(0)
 
-    def attack(self, ori_features, ori_adj, labels, idx_train, n_perturbations):
+    def attack(self, ori_features, ori_adj, labels, idx_train, n_perturbations, **kwargs):
         victim_model = self.surrogate
         self.sparse_features = sp.issparse(ori_features)
         ori_adj, ori_features, labels = utils.to_tensor(ori_adj, ori_features, labels, device=self.device)

--- a/deeprobust/graph/global_attack/ig_attack.py
+++ b/deeprobust/graph/global_attack/ig_attack.py
@@ -37,7 +37,7 @@ class IGAttack(BaseAttack):
             self.feature_changes = Parameter(torch.FloatTensor(feature_shape))
             self.feature_changes.data.fill_(0)
 
-    def attack(self, ori_features, ori_adj, labels, idx_train, perturbations):
+    def attack(self, ori_features, ori_adj, labels, idx_train, n_perturbations):
         victim_model = self.surrogate
         self.sparse_features = sp.issparse(ori_features)
         ori_adj, ori_features, labels = utils.to_tensor(ori_adj, ori_features, labels, device=self.device)
@@ -51,7 +51,7 @@ class IGAttack(BaseAttack):
         import ipdb
         ipdb.set_trace()
 
-        for t in tqdm(range(perturbations)):
+        for t in tqdm(range(n_perturbations)):
             modified_adj
 
         self.adj_changes.data.copy_(torch.tensor(best_s))

--- a/deeprobust/graph/global_attack/random.py
+++ b/deeprobust/graph/global_attack/random.py
@@ -15,12 +15,12 @@ class Random(BaseAttack):
         self.add_nodes = add_nodes
         assert not self.attack_features, 'RND does NOT support attacking features'
 
-    def attack(self, adj, n_perturbations, type='add'):
+    def attack(self, ori_adj, n_perturbations, type='add', **kwargs):
         '''
         type: 'add', 'remove', 'flip'
         '''
         if self.attack_structure:
-            modified_adj = self.perturb_adj(adj, n_perturbations, type)
+            modified_adj = self.perturb_adj(ori_adj, n_perturbations, type)
             return modified_adj
 
     def perturb_adj(self, adj, n_perturbations, type='add'):

--- a/deeprobust/graph/global_attack/topology_attack.py
+++ b/deeprobust/graph/global_attack/topology_attack.py
@@ -39,7 +39,7 @@ class PGDAttack(BaseAttack):
 
         self.complementary = None
 
-    def attack(self, ori_features, ori_adj, labels, idx_train, perturbations, epochs=200):
+    def attack(self, ori_features, ori_adj, labels, idx_train, n_perturbations, epochs=200):
         victim_model = self.surrogate
 
         self.sparse_features = sp.issparse(ori_features)
@@ -62,12 +62,12 @@ class PGDAttack(BaseAttack):
                 lr = 0.1 / np.sqrt(t+1)
                 self.adj_changes.data.add_(lr * adj_grad)
 
-            self.projection(perturbations)
+            self.projection(n_perturbations)
 
-        self.random_sample(ori_adj, ori_features, labels, idx_train, perturbations)
+        self.random_sample(ori_adj, ori_features, labels, idx_train, n_perturbations)
         self.modified_adj = self.get_modified_adj(ori_adj).detach()
 
-    def random_sample(self, ori_adj, ori_features, labels, idx_train, perturbations):
+    def random_sample(self, ori_adj, ori_features, labels, idx_train, n_perturbations):
         K = 20
         best_loss = -1000
         victim_model = self.surrogate
@@ -77,7 +77,7 @@ class PGDAttack(BaseAttack):
                 sampled = np.random.binomial(1, s)
 
                 print(sampled.sum())
-                if sampled.sum() > perturbations:
+                if sampled.sum() > n_perturbations:
                     continue
                 self.adj_changes.data.copy_(torch.tensor(sampled))
                 modified_adj = self.get_modified_adj(ori_adj)
@@ -104,12 +104,12 @@ class PGDAttack(BaseAttack):
             # loss = torch.clamp(margin.sum()+50, min=k)
         return loss
 
-    def projection(self, perturbations):
+    def projection(self, n_perturbations):
         # projected = torch.clamp(self.adj_changes, 0, 1)
-        if torch.clamp(self.adj_changes, 0, 1).sum() > perturbations:
+        if torch.clamp(self.adj_changes, 0, 1).sum() > n_perturbations:
             left = (self.adj_changes - 1).min()
             right = self.adj_changes.max()
-            miu = self.bisection(left, right, perturbations, epsilon=1e-5)
+            miu = self.bisection(left, right, n_perturbations, epsilon=1e-5)
             self.adj_changes.data.copy_(torch.clamp(self.adj_changes.data - miu, min=0, max=1))
         else:
             self.adj_changes.data.copy_(torch.clamp(self.adj_changes.data, min=0, max=1))
@@ -128,9 +128,9 @@ class PGDAttack(BaseAttack):
 
         return modified_adj
 
-    def bisection(self, a, b, perturbations, epsilon):
+    def bisection(self, a, b, n_perturbations, epsilon):
         def func(x):
-            return torch.clamp(self.adj_changes-x, 0, 1).sum() - perturbations
+            return torch.clamp(self.adj_changes-x, 0, 1).sum() - n_perturbations
 
         miu = a
         while ((b-a) >= epsilon):
@@ -154,7 +154,7 @@ class MinMax(PGDAttack):
         super(MinMax, self).__init__(model, nnodes, loss_type, feature_shape, attack_structure, attack_features, device=device)
 
 
-    def attack(self, ori_features, ori_adj, labels, idx_train, perturbations):
+    def attack(self, ori_features, ori_adj, labels, idx_train, n_perturbations):
         victim_model = self.surrogate
 
         self.sparse_features = sp.issparse(ori_features)
@@ -195,7 +195,7 @@ class MinMax(PGDAttack):
                 self.adj_changes.data.add_(lr * adj_grad)
 
             # self.adj_changes.grad.zero_()
-            self.projection(perturbations)
+            self.projection(n_perturbations)
 
-        self.random_sample(ori_adj, ori_features, labels, idx_train, perturbations)
+        self.random_sample(ori_adj, ori_features, labels, idx_train, n_perturbations)
         self.modified_adj = self.get_modified_adj(ori_adj).detach()

--- a/deeprobust/graph/global_attack/topology_attack.py
+++ b/deeprobust/graph/global_attack/topology_attack.py
@@ -39,7 +39,7 @@ class PGDAttack(BaseAttack):
 
         self.complementary = None
 
-    def attack(self, ori_features, ori_adj, labels, idx_train, n_perturbations, epochs=200):
+    def attack(self, ori_features, ori_adj, labels, idx_train, n_perturbations, epochs=200, **kwargs):
         victim_model = self.surrogate
 
         self.sparse_features = sp.issparse(ori_features)


### PR DESCRIPTION
Closes #22. 

I made the following changes to `DICE`, `IGAttack`, `Random`, `PGDAttack` and `MinMax`:
- Changed `adj` to `ori_adj` in attack methods
- Changed `perturbations` to `n_perturbations`
- Added `**kwargs` to the attack methods

And changed the base class: 
- The variables `ori_adj` and `n_perturbations` were put into the base class `attack` method with a docstring

In this docstring, I've put  that `ori_adj` is of type `scipy.sparse.csr_matrix`. This input type doesn't work for some methods, and this is something I recommend we address in a separate issue.