### PR TITLE
Fix type in docstring

### DIFF
--- a/deeprobust/graph/defense/gcn_preprocess.py
+++ b/deeprobust/graph/defense/gcn_preprocess.py
@@ -207,7 +207,7 @@ class GCNJaccard(GCN):
             node training indices
         idx_val :
             node validation indices. If not given (None), GCN training process will not adpot early stopping
-        threshold : int
+        threshold : float
             similarity threshold for dropping edges. If two connected nodes with similarity smaller than threshold, the edge between them will be removed.
         train_iters : int
             number of training epochs

--- a/deeprobust/graph/utils.py
+++ b/deeprobust/graph/utils.py
@@ -56,7 +56,7 @@ def preprocess(adj, features, labels, preprocess_adj=False, preprocess_feature=F
         node labels
     preprocess_adj : bool
         whether to normalize the adjacency matrix
-    preprocess_feature :
+    preprocess_feature : bool
         whether to normalize the feature matrix
     sparse : bool
        whether to return sparse tensor


### PR DESCRIPTION
Thank you for making this great library.
I found a mistake in the docstring of GCNJaccard. The type of threshold should be float, not int.
And also I add a type to preprocess_features in the arguments of preprocess function.