### PR TITLE
implement faster Node2Vec with scipy and numba.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,4 @@ Pillow==7.0.0
 scikit_learn==0.22.1
 tensorboardX==2.0
 tqdm==4.42.1
-node2vec==0.3.2
 gensim==3.8.3


### PR DESCRIPTION
I improve the code of Node2Vec and remove the requirement of node2vec==0.3.2.
The implement is based on scipy and numba, which is 10x faster than before. See the following comparison:

Node2Vec in [node2vec](https://github.com/eliorc/node2vec/blob/master/node2vec/node2vec.py):
+ before attack
```python
%%time
model = Node2Vec()
model.fit(adj)
model.evaluate_node_classification(labels, idx_train, idx_test)

Computing transition probabilities: 100%|██████████| 2810/2810 [00:01<00:00, 1542.39it/s]
Micro F1: 0.8091637010676157
Macro F1: 0.7912831590583134
Wall time: 47.9 s
```
+ after attack
```python
%%time
model = Node2Vec()
model.fit(modified_adj)
model.evaluate_node_classification(labels, idx_train, idx_test)

Computing transition probabilities: 100%|██████████| 2810/2810 [00:02<00:00, 1002.49it/s]
Micro F1: 0.7415480427046264
Macro F1: 0.7106148220982006
Wall time: 41.1 s
```

---

Now

+ before attack
```python
%%time
model = Node2Vec()
model.fit(adj)
model.evaluate_node_classification(labels, idx_train, idx_test)

Micro F1: 0.8207295373665481
Macro F1: 0.7911009841941256
Wall time: 5.48 s
```
+ after attack
```python
%%time
model = Node2Vec()
model.fit(modified_adj)
model.evaluate_node_classification(labels, idx_train, idx_test)

Micro F1: 0.75711743772242
Macro F1: 0.7171709903118675
Wall time: 4.12 s
```


