### PR TITLE
Mettack for directed graphs

### DIFF
--- a/deeprobust/graph/global_attack/mettack.py
+++ b/deeprobust/graph/global_attack/mettack.py
@@ -119,7 +119,7 @@ class BaseMeta(BaseAttack):
         allowed_mask, current_ratio = utils.likelihood_ratio_filter(t_possible_edges,
                                                                     modified_adj,
                                                                     ori_adj, t_d_min,
-                                                                    ll_cutoff)
+                                                                    ll_cutoff, undirected=self.undirected)
         return allowed_mask, current_ratio
 
     def get_adj_score(self, adj_grad, modified_adj, ori_adj, ll_constraint, ll_cutoff):

--- a/deeprobust/graph/global_attack/mettack.py
+++ b/deeprobust/graph/global_attack/mettack.py
@@ -73,7 +73,8 @@ class BaseMeta(BaseAttack):
         adj_changes_square = self.adj_changes - torch.diag(torch.diag(self.adj_changes, 0))
         # ind = np.diag_indices(self.adj_changes.shape[0]) # this line seems useless
         if self.undirected:
-            adj_changes_square = torch.clamp(adj_changes_square + torch.transpose(adj_changes_square, 1, 0), -1, 1)
+            adj_changes_square = adj_changes_square + torch.transpose(adj_changes_square, 1, 0)
+        adj_changes_square = torch.clamp(adj_changes_square, -1, 1)
         modified_adj = adj_changes_square + ori_adj
         return modified_adj
 
@@ -111,7 +112,10 @@ class BaseMeta(BaseAttack):
         Note that different data type (float, double) can effect the final results.
         """
         t_d_min = torch.tensor(2.0).to(self.device)
-        t_possible_edges = np.array(np.triu(np.ones((self.nnodes, self.nnodes)), k=1).nonzero()).T
+        if self.undirected:
+            t_possible_edges = np.array(np.triu(np.ones((self.nnodes, self.nnodes)), k=1).nonzero()).T
+        else:
+            t_possible_edges = np.array((np.ones((self.nnodes, self.nnodes)) - np.eye(self.nnodes)).nonzero()).T
         allowed_mask, current_ratio = utils.likelihood_ratio_filter(t_possible_edges,
                                                                     modified_adj,
                                                                     ori_adj, t_d_min,

--- a/deeprobust/graph/global_attack/mettack.py
+++ b/deeprobust/graph/global_attack/mettack.py
@@ -363,7 +363,8 @@ class Metattack(BaseMeta):
                 adj_meta_argmax = torch.argmax(adj_meta_score)
                 row_idx, col_idx = utils.unravel_index(adj_meta_argmax, ori_adj.shape)
                 self.adj_changes.data[row_idx][col_idx] += (-2 * modified_adj[row_idx][col_idx] + 1)
-                self.adj_changes.data[col_idx][row_idx] += (-2 * modified_adj[row_idx][col_idx] + 1)
+                if self.undirected:
+                    self.adj_changes.data[col_idx][row_idx] += (-2 * modified_adj[row_idx][col_idx] + 1)
             else:
                 feature_meta_argmax = torch.argmax(feature_meta_score)
                 row_idx, col_idx = utils.unravel_index(feature_meta_argmax, ori_features.shape)
@@ -558,7 +559,8 @@ class MetaApprox(BaseMeta):
                 adj_meta_argmax = torch.argmax(adj_meta_score)
                 row_idx, col_idx = utils.unravel_index(adj_meta_argmax, ori_adj.shape)
                 self.adj_changes.data[row_idx][col_idx] += (-2 * modified_adj[row_idx][col_idx] + 1)
-                self.adj_changes.data[col_idx][row_idx] += (-2 * modified_adj[row_idx][col_idx] + 1)
+                if self.undirected:
+                    self.adj_changes.data[col_idx][row_idx] += (-2 * modified_adj[row_idx][col_idx] + 1)
             else:
                 feature_meta_argmax = torch.argmax(feature_meta_score)
                 row_idx, col_idx = utils.unravel_index(feature_meta_argmax, ori_features.shape)

--- a/deeprobust/graph/utils.py
+++ b/deeprobust/graph/utils.py
@@ -596,7 +596,7 @@ def likelihood_ratio_filter(node_pairs, modified_adjacency, original_adjacency, 
     allowed_mask = torch.zeros(modified_adjacency.shape)
     allowed_mask[filtered_edges.T] = 1
     if undirected:
-	allowed_mask += allowed_mask.t()
+        allowed_mask += allowed_mask.t()
     return allowed_mask, current_ratio
 
 

--- a/deeprobust/graph/utils.py
+++ b/deeprobust/graph/utils.py
@@ -549,7 +549,7 @@ def get_degree_squence(adj):
     except:
         return ts.sum(adj, dim=1).to_dense()
 
-def likelihood_ratio_filter(node_pairs, modified_adjacency, original_adjacency, d_min, threshold=0.004):
+def likelihood_ratio_filter(node_pairs, modified_adjacency, original_adjacency, d_min, threshold=0.004, undirected=True):
     """
     Filter the input node pairs based on the likelihood ratio test proposed by Zügner et al. 2018, see
     https://dl.acm.org/citation.cfm?id=3220078. In essence, for each node pair return 1 if adding/removing the edge
@@ -595,7 +595,8 @@ def likelihood_ratio_filter(node_pairs, modified_adjacency, original_adjacency, 
 
     allowed_mask = torch.zeros(modified_adjacency.shape)
     allowed_mask[filtered_edges.T] = 1
-    allowed_mask += allowed_mask.t()
+    if undirected:
+	allowed_mask += allowed_mask.t()
     return allowed_mask, current_ratio
 
 


### PR DESCRIPTION
The original implementation of Mettack is designed only for undirected graphs.  I've added an option `undirected` to `MetaBase`, `Metattack`, `MetaApprox` and `utils.likelihood_ratio_filter` and adapted their codes to support both undirected and directed graphs.  I set the default value of `undirected` to `True` so that it is supposed be compatible with existing code.  