### PR TITLE
add SGAttack in Adversarial Attack on Large Scale Graph

### DIFF
--- a/deeprobust/graph/README.md
+++ b/deeprobust/graph/README.md
@@ -51,6 +51,7 @@ For more details, please take a look at [dataset.py](https://github.com/DSE-MSU/
 | IG-Attack | Targeted Attack | Structure<br>Features| Both | Node Classification | [Adversarial Examples on Graph Data: Deep Insights into Attack and Defense](https://arxiv.org/pdf/1903.01610.pdf)|[test_ig.py](https://github.com/DSE-MSU/DeepRobust/blob/master/examples/graph/test_ig.py) |
 | NIPA | Global Attack | Structure | Poisoning |  Node Classification | [Non-target-specific Node Injection Attacks on Graph Neural Networks: A Hierarchical Reinforcement Learning Approach](https://faculty.ist.psu.edu/vhonavar/Papers/www20.pdf) | [test_nipa.py](https://github.com/DSE-MSU/DeepRobust/blob/master/examples/graph/test_nipa.py) |
 | RND | Targeted Attack<br>Global Attack | Structure<br>Features<br>Adding Nodes | Both | Node Classification | |[test_rnd.py](https://github.com/DSE-MSU/DeepRobust/blob/master/examples/graph/test_rnd.py) |
+| SGAttack | Targeted Attack | Structure | Poisoning | Node Classification | [Adversarial Attack on Large Scale Graph](https://arxiv.org/abs/2009.03488)| [test_sga.py](https://github.com/DSE-MSU/DeepRobust/blob/master/examples/graph/test_sga.py) |
 
 # Defense Methods
 |   Defense Methods   | Defense Type | Apply Domain | Paper | Code |

--- a/deeprobust/graph/targeted_attack/__init__.py
+++ b/deeprobust/graph/targeted_attack/__init__.py
@@ -4,5 +4,6 @@ from .rnd import RND
 from .nettack import Nettack
 from .ig_attack import IGAttack
 from .rl_s2v import RLS2V
+from .sga import SGAttack
 
-__all__ = ['BaseAttack', 'FGA', 'RND', 'Nettack', 'IGAttack', 'RLS2V']
+__all__ = ['BaseAttack', 'FGA', 'RND', 'Nettack', 'IGAttack', 'RLS2V', 'SGAttack']

--- a/deeprobust/graph/targeted_attack/sga.py
+++ b/deeprobust/graph/targeted_attack/sga.py
@@ -1,0 +1,360 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import numpy as np
+import scipy.sparse as sp
+from deeprobust.graph.targeted_attack import BaseAttack
+from deeprobust.graph import utils
+from torch_scatter import scatter_add
+from collections import namedtuple
+
+from numba import njit
+from numba import types
+from numba.typed import Dict
+
+SubGraph = namedtuple('SubGraph', ['edge_index', 'non_edge_index',
+                                   'self_loop', 'self_loop_weight',
+                                   'edge_weight', 'non_edge_weight',
+                                   'edges_all'])
+
+
+class SGAttack(BaseAttack):
+    """SGAttack proposed in `Adversarial Attack on Large Scale Graph` TKDE 2021
+    <https://arxiv.org/abs/2009.03488>
+
+    SGAttack follows these steps::
+    + training a surrogate SGC model with hop K
+    + extrack a K-hop subgraph centered at target node
+    + choose top-N attacker nodes that belong to the best wrong classes of target node
+    + compute gradients w.r.t to the subgraph to add or remove edges
+
+    Parameters
+    ----------
+    model :
+        model to attack
+    nnodes : int
+        number of nodes in the input graph
+    attack_structure : bool
+        whether to attack graph structure
+    attack_features : bool
+        whether to attack node features
+    device: str
+        'cpu' or 'cuda'
+
+    Examples
+    --------
+
+    >>> from deeprobust.graph.data import Dataset
+    >>> from deeprobust.graph.defense import SGC
+    >>> data = Dataset(root='/tmp/', name='cora')
+    >>> adj, features, labels = data.adj, data.features, data.labels
+    >>> idx_train, idx_val, idx_test = data.idx_train, data.idx_val, data.idx_test
+    >>> surrogate = SGC(nfeat=features.shape[1], K=3, lr=0.1,
+              nclass=labels.max().item() + 1, device='cuda')
+    >>> surrogate = surrogate.to('cuda')
+    >>> pyg_data = Dpr2Pyg(data) # convert deeprobust dataset to pyg dataset
+    >>> surrogate.fit(pyg_data, train_iters=200, patience=200, verbose=True) # train with earlystopping
+    >>> from deeprobust.graph.targeted_attack import SGAttack
+    >>> # Setup Attack Model
+    >>> target_node = 0
+    >>> model = SGAttack(surrogate, attack_structure=True, device=device)
+    >>> # Attack
+    >>> model.attack(features, adj, labels, target_node, n_perturbations=5)
+    >>> modified_adj = model.modified_adj
+    >>> modified_features = model.modified_features
+    """
+
+    def __init__(self, model, nnodes=None, attack_structure=True, attack_features=False, device='cpu'):
+
+        assert not attack_features, 'Currently `SGAttack` does not support `attack_features`.'
+        super(SGAttack, self).__init__(model=None, nnodes=nnodes,
+                                       attack_structure=attack_structure, attack_features=attack_features, device=device)
+
+        self.target_node = None
+        self.logits = model.predict()
+        self.K = model.conv1.K
+        W = model.conv1.lin.weight.to(device)
+        b = model.conv1.lin.bias
+        if b is not None:
+            b = b.to(device)
+
+        self.weight, self.bias = W, b
+
+    def get_linearized_weight(self, features):
+        if not torch.is_tensor(features):
+            features = torch.tensor(features, device=self.device)
+        return F.linear(features, self.weight), self.bias
+
+    def attack(self, features, adj, labels, target_node, n_perturbations, direct=True, n_influencers=3, **kwargs):
+        """Generate perturbations on the input graph.
+
+        Parameters
+        ----------
+        features :
+            Original (unperturbed) node feature matrix
+        adj :
+            Original (unperturbed) adjacency matrix
+        labels :
+            node labels
+        target_node : int
+            target_node node index to be attacked
+        n_perturbations : int
+            Number of perturbations on the input graph. Perturbations could
+            be edge removals/additions or feature removals/additions.
+        direct: bool
+            whether to conduct direct attack
+        n_influencers : int
+            number of the top influencers to choose. For direct attack, it will set as `n_perturbations`.
+        """
+        if sp.issparse(features):
+            # to dense numpy matrix
+            features = features.A
+
+        if torch.is_tensor(adj):
+            adj = utils.to_scipy(adj).csr()
+
+        modified_adj = adj.copy().tolil()
+
+        target_label = torch.LongTensor([labels[target_node]])
+        labels = torch.tensor(labels)
+        best_wrong_label = torch.LongTensor([(self.logits[target_node].cpu() - 1000 * torch.eye(self.logits.size(1))[target_label]).argmax()])
+        self.selfloop_degree = torch.tensor(adj.sum(1).A1 + 1, device=self.device)
+        self.target_label = target_label.to(self.device)
+        self.best_wrong_label = best_wrong_label.to(self.device)
+        self.n_perturbations = n_perturbations
+        self.W, self.b = self.get_linearized_weight(features)
+        self.ori_adj = adj
+        self.target_node = target_node
+        self.direct = direct
+
+        attacker_nodes = torch.where(labels == best_wrong_label)[0]
+        subgraph = self.get_subgraph(attacker_nodes, n_influencers)
+
+        if not direct:
+            # for indirect attack, the edges adjacent to targeted node should not be considered
+            mask = torch.logical_and(subgraph.edge_index[0] != target_node, subgraph.edge_index[1] != target_node).float().to(self.device)
+        else:
+            mask = 1.0
+
+        structure_perturbations = []
+        for _ in range(n_perturbations):
+            edge_grad, non_edge_grad = self.compute_gradient(subgraph)
+            with torch.no_grad():
+                edge_grad *= (-2 * subgraph.edge_weight + 1) * mask
+                non_edge_grad *= -2 * subgraph.non_edge_weight + 1
+
+            max_edge_grad, max_edge_idx = torch.max(edge_grad, dim=0)
+            max_non_edge_grad, max_non_edge_idx = torch.max(non_edge_grad, dim=0)
+
+            if max_edge_grad > max_non_edge_grad:
+                # remove one edge
+                best_edge = subgraph.edge_index[:, max_edge_idx]
+                subgraph.edge_weight.data[max_edge_idx] = 0.0
+                self.selfloop_degree[best_edge] -= 1.0
+            else:
+                # add one edge
+                best_edge = subgraph.non_edge_index[:, max_non_edge_idx]
+                subgraph.non_edge_weight.data[max_non_edge_idx] = 1.0
+                self.selfloop_degree[best_edge] += 1.0
+
+            u, v = best_edge.tolist()
+            structure_perturbations.append((u, v))
+            modified_adj[u, v] = modified_adj[v, u] = 1 - modified_adj[u, v]
+
+        self.modified_adj = modified_adj
+        self.modified_features = features
+        self.structure_perturbations = structure_perturbations
+
+    def get_subgraph(self, attacker_nodes, n_influencers=None):
+        target_node = self.target_node
+        neighbors = self.ori_adj[target_node].indices
+
+        sub_edges, sub_nodes = self.ego_subgraph()
+
+        if self.direct or n_influencers is not None:
+            influencers = [target_node]
+            attacker_nodes = np.setdiff1d(attacker_nodes, neighbors)
+        else:
+            influencers = neighbors
+
+        subgraph = self.subgraph_processing(influencers, attacker_nodes, sub_nodes, sub_edges)
+
+        if n_influencers is not None:
+            if self.direct:
+                influencers = [target_node]
+                attacker_nodes = self.get_topk_influencers(subgraph, k=self.n_perturbations + 1)
+
+            else:
+                influencers = neighbors
+                attacker_nodes = self.get_topk_influencers(subgraph, k=n_influencers)
+
+            subgraph = self.subgraph_processing(influencers, attacker_nodes, sub_nodes, sub_edges)
+        return subgraph
+
+    def get_topk_influencers(self, subgraph, k):
+        _, non_edge_grad = self.compute_gradient(subgraph)
+        _, topk_nodes = torch.topk(non_edge_grad, k=k, sorted=False)
+
+        influencers = subgraph.non_edge_index[1][topk_nodes.cpu()]
+        return influencers
+
+    def subgraph_processing(self, influencers, attacker_nodes, sub_nodes, sub_edges):
+
+        row = np.repeat(influencers, len(attacker_nodes))
+        col = np.tile(attacker_nodes, len(influencers))
+        non_edges = np.row_stack([row, col])
+
+        if len(influencers) > 1:
+            mask = self.ori_adj[non_edges[0],
+                                non_edges[1]].A1 == 0
+            non_edges = non_edges[:, mask]
+
+        nodes = np.union1d(sub_nodes, attacker_nodes)
+        self_loop = np.row_stack([nodes, nodes])
+
+        edges_all = np.hstack([sub_edges, sub_edges[[1, 0]], non_edges,
+                               non_edges[[1, 0]], self_loop
+                               ])
+
+        edges_all = torch.tensor(edges_all, device=self.device)
+        edge_weight = nn.Parameter(torch.ones(sub_edges.shape[1], device=self.device))
+        non_edge_weight = nn.Parameter(torch.zeros(non_edges.shape[1], device=self.device))
+        self_loop_weight = torch.ones(nodes.shape[0], device=self.device)
+
+        edge_index = torch.tensor(sub_edges)
+        non_edge_index = torch.tensor(non_edges)
+        self_loop = torch.tensor(self_loop)
+
+        subgraph = SubGraph(edge_index=edge_index, non_edge_index=non_edge_index,
+                            self_loop=self_loop, edges_all=edges_all,
+                            edge_weight=edge_weight, non_edge_weight=non_edge_weight,
+                            self_loop_weight=self_loop_weight)
+        return subgraph
+
+    def SGCCov(self, x, edge_index, edge_weight):
+        row, col = edge_index
+        for _ in range(self.K):
+            src = x[row] * edge_weight.view(-1, 1)
+            x = scatter_add(src, col, dim=-2, dim_size=x.size(0))
+        return x
+
+    def compute_gradient(self, subgraph, eps=5.0):
+        edge_weight = subgraph.edge_weight
+        non_edge_weight = subgraph.non_edge_weight
+        self_loop_weight = subgraph.self_loop_weight
+        weights = torch.cat([edge_weight, edge_weight,
+                             non_edge_weight, non_edge_weight,
+                             self_loop_weight], dim=0)
+
+        weights = self.gcn_norm(subgraph.edges_all, weights, self.selfloop_degree)
+        logit = self.SGCCov(self.W, subgraph.edges_all, weights)
+        logit = logit[self.target_node]
+        if self.b is not None:
+            logit += self.b
+        # model calibration
+        logit = F.log_softmax(logit.view(1, -1) / eps, dim=1)
+        loss = F.nll_loss(logit, self.target_label) - F.nll_loss(logit, self.best_wrong_label)
+        gradients = torch.autograd.grad(loss, [edge_weight, non_edge_weight], create_graph=False)
+        return gradients
+
+    def ego_subgraph(self):
+        import graphgallery.functional as gf
+        sub_edges, sub_nodes = gf.ego_graph(self.ori_adj, self.target_node, self.K)
+        sub_edges = sub_edges.T  # shape [2, M]
+        return sub_edges, sub_nodes
+
+    @staticmethod
+    def gcn_norm(edge_index, weights, degree):
+        row, col = edge_index
+        inv_degree = torch.pow(degree, -0.5)
+        normed_weights = weights * inv_degree[row] * inv_degree[col]
+        return normed_weights
+
+
+@njit
+def extra_edges(indices, indptr,
+                last_level, seen,
+                hops: int):
+    edges = []
+    mapping = Dict.empty(
+        key_type=types.int64,
+        value_type=types.int64,
+    )
+    for u in last_level:
+        nbrs = indices[indptr[u]:indptr[u + 1]]
+        nbrs = nbrs[seen[nbrs] == hops]
+        mapping[u] = 1
+        for v in nbrs:
+            if not v in mapping:
+                edges.append((u, v))
+    return edges
+
+
+def ego_graph(adj_matrix, targets, hops: int = 1):
+    """Returns induced subgraph of neighbors centered at node n within
+    a given radius.
+
+    Parameters
+    ----------
+    adj_matrix : A Scipy sparse adjacency matrix
+        representing a graph
+
+    targets : Center nodes
+        A single node or a list of nodes
+
+    hops : number, optional
+        Include all neighbors of distance<=hops from nodes.
+
+    Returns
+    -------
+    (edges, nodes):
+        edges: shape [2, M], the edges of the subgraph
+        nodes: shape [N], the nodes of the subgraph
+
+    Notes
+    -----
+    This is a faster implementation of 
+    `networkx.ego_graph`
+
+
+    See Also
+    --------
+    networkx.ego_graph
+
+    """
+
+    if np.ndim(targets) == 0:
+        targets = [targets]
+    elif isinstance(targets, np.ndarray):
+        targets = targets.tolist()
+    else:
+        targets = list(targets)
+
+    indices = adj_matrix.indices
+    indptr = adj_matrix.indptr
+
+    edges = {}
+    start = 0
+    N = adj_matrix.shape[0]
+    seen = np.zeros(N) - 1
+    seen[targets] = 0
+    for level in range(hops):
+        end = len(targets)
+        while start < end:
+            head = targets[start]
+            nbrs = indices[indptr[head]:indptr[head + 1]]
+            for u in nbrs:
+                if seen[u] < 0:
+                    targets.append(u)
+                    seen[u] = level + 1
+                if (u, head) not in edges:
+                    edges[(head, u)] = level + 1
+
+            start += 1
+
+    if len(targets[start:]):
+        e = extra_edges(indices, indptr, np.array(targets[start:]), seen, hops)
+    else:
+        e = []
+
+    return np.transpose(list(edges.keys()) + e), np.asarray(targets)

--- a/examples/graph/test_sga.py
+++ b/examples/graph/test_sga.py
@@ -1,0 +1,202 @@
+import torch
+import numpy as np
+from deeprobust.graph.defense import GCN
+from deeprobust.graph.targeted_attack import SGAttack
+from deeprobust.graph.utils import *
+from deeprobust.graph.data import Dataset, Dpr2Pyg
+from deeprobust.graph.defense import SGC
+
+import argparse
+from tqdm import tqdm
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--seed', type=int, default=15, help='Random seed.')
+parser.add_argument('--dataset', type=str, default='cora', choices=['cora', 'cora_ml', 'citeseer', 'polblogs', 'pubmed'], help='dataset')
+parser.add_argument('--ptb_rate', type=float, default=0.05, help='pertubation rate')
+
+args = parser.parse_args()
+args.cuda = torch.cuda.is_available()
+print('cuda: %s' % args.cuda)
+device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+np.random.seed(args.seed)
+torch.manual_seed(args.seed)
+if args.cuda:
+    torch.cuda.manual_seed(args.seed)
+
+data = Dataset(root='/tmp/', name=args.dataset)
+adj, features, labels = data.adj, data.features, data.labels
+
+idx_train, idx_val, idx_test = data.idx_train, data.idx_val, data.idx_test
+
+idx_unlabeled = np.union1d(idx_val, idx_test)
+
+# Setup Surrogate model
+surrogate = SGC(nfeat=features.shape[1],
+                nclass=labels.max().item() + 1, K=2,
+                lr=0.01, device=device).to(device)
+
+pyg_data = Dpr2Pyg(data)
+surrogate.fit(pyg_data, verbose=False)  # train with earlystopping
+surrogate.test()
+
+# Setup Attack Model
+target_node = 0
+assert target_node in idx_unlabeled
+
+model = SGAttack(surrogate, attack_structure=True, device=device)
+model = model.to(device)
+
+
+def main():
+    degrees = adj.sum(0).A1
+    # How many perturbations to perform. Default: Degree of the node
+    n_perturbations = int(degrees[target_node])
+
+    # direct attack
+    model.attack(features, adj, labels, target_node, n_perturbations)
+    # # indirect attack/ influencer attack
+    # model.attack(features, adj, labels, target_node, n_perturbations, direct=False, n_influencers=5)
+    modified_adj = model.modified_adj
+    modified_features = model.modified_features
+    print(model.structure_perturbations)
+    print('=== testing GCN on original(clean) graph ===')
+    test(adj, features, target_node)
+    print('=== testing GCN on perturbed graph ===')
+    test(modified_adj, modified_features, target_node)
+
+
+def test(adj, features, target_node):
+    ''' test on GCN '''
+    gcn = GCN(nfeat=features.shape[1],
+              nhid=16,
+              nclass=labels.max().item() + 1,
+              dropout=0.5, device=device)
+
+    gcn = gcn.to(device)
+
+    gcn.fit(features, adj, labels, idx_train, idx_val, patience=30)
+
+    gcn.eval()
+    output = gcn.predict()
+    probs = torch.exp(output[[target_node]])[0]
+    print('Target node probs: {}'.format(probs.detach().cpu().numpy()))
+    acc_test = accuracy(output[idx_test], labels[idx_test])
+
+    print("Overall test set results:",
+          "accuracy= {:.4f}".format(acc_test.item()))
+
+    return acc_test.item()
+
+
+def select_nodes(target_gcn=None):
+    '''
+    selecting nodes as reported in Nettack paper:
+    (i) the 10 nodes with highest margin of classification, i.e. they are clearly correctly classified,
+    (ii) the 10 nodes with lowest margin (but still correctly classified) and
+    (iii) 20 more nodes randomly
+    '''
+
+    if target_gcn is None:
+        target_gcn = GCN(nfeat=features.shape[1],
+                         nhid=16,
+                         nclass=labels.max().item() + 1,
+                         dropout=0.5, device=device)
+        target_gcn = target_gcn.to(device)
+        target_gcn.fit(features, adj, labels, idx_train, idx_val, patience=30)
+    target_gcn.eval()
+    output = target_gcn.predict()
+
+    margin_dict = {}
+    for idx in idx_test:
+        margin = classification_margin(output[idx], labels[idx])
+        if margin < 0:  # only keep the nodes correctly classified
+            continue
+        margin_dict[idx] = margin
+    sorted_margins = sorted(margin_dict.items(), key=lambda x: x[1], reverse=True)
+    high = [x for x, y in sorted_margins[: 10]]
+    low = [x for x, y in sorted_margins[-10:]]
+    other = [x for x, y in sorted_margins[10: -10]]
+    other = np.random.choice(other, 20, replace=False).tolist()
+
+    return high + low + other
+
+
+def multi_test_poison():
+    # test on 40 nodes on poisoining attack
+    cnt = 0
+    degrees = adj.sum(0).A1
+    node_list = select_nodes()
+    num = len(node_list)
+    print('=== [Poisoning] Attacking %s nodes respectively ===' % num)
+    for target_node in tqdm(node_list):
+        n_perturbations = int(degrees[target_node])
+        model = SGAttack(surrogate, attack_structure=True, device=device)
+        model = model.to(device)
+        model.attack(features, adj, labels, target_node, n_perturbations, verbose=False)
+        modified_adj = model.modified_adj
+        modified_features = model.modified_features
+        acc = single_test(modified_adj, modified_features, target_node)
+        if acc == 0:
+            cnt += 1
+    print('misclassification rate : %s' % (cnt / num))
+
+
+def single_test(adj, features, target_node, gcn=None):
+    if gcn is None:
+        # test on GCN (poisoning attack)
+        gcn = GCN(nfeat=features.shape[1],
+                  nhid=16,
+                  nclass=labels.max().item() + 1,
+                  dropout=0.5, device=device)
+
+        gcn = gcn.to(device)
+
+        gcn.fit(features, adj, labels, idx_train, idx_val, patience=30)
+        gcn.eval()
+        output = gcn.predict()
+    else:
+        # test on GCN (evasion attack)
+        output = gcn.predict(features, adj)
+    probs = torch.exp(output[[target_node]])
+
+    # acc_test = accuracy(output[[target_node]], labels[target_node])
+    acc_test = (output.argmax(1)[target_node] == labels[target_node])
+    return acc_test.item()
+
+
+def multi_test_evasion():
+    # test on 40 nodes on evasion attack
+    target_gcn = GCN(nfeat=features.shape[1],
+                     nhid=16,
+                     nclass=labels.max().item() + 1,
+                     dropout=0.5, device=device)
+
+    target_gcn = target_gcn.to(device)
+
+    target_gcn.fit(features, adj, labels, idx_train, idx_val, patience=30)
+
+    cnt = 0
+    degrees = adj.sum(0).A1
+    node_list = select_nodes(target_gcn)
+    num = len(node_list)
+
+    print('=== [Evasion] Attacking %s nodes respectively ===' % num)
+    for target_node in tqdm(node_list):
+        n_perturbations = int(degrees[target_node])
+        model = SGAttack(surrogate, attack_structure=True, device=device)
+        model = model.to(device)
+        model.attack(features, adj, labels, target_node, n_perturbations, verbose=False)
+        modified_adj = model.modified_adj
+        modified_features = model.modified_features
+
+        acc = single_test(modified_adj, modified_features, target_node, gcn=target_gcn)
+        if acc == 0:
+            cnt += 1
+    print('misclassification rate : %s' % (cnt / num))
+
+
+if __name__ == '__main__':
+    main()
+    multi_test_poison()
+    multi_test_evasion()


### PR DESCRIPTION
Hi, I've implemented the method `SGAttack` in [Adversarial Attack on Large Scale Graph](https://arxiv.org/abs/2009.03488), which has been published in TKDE 2021.

`SGAttack` (or SGA in short) is an adversarial targeted attack method, which extracts a much smaller subgraph centered at the target node, thereby addressing the difficulty of conducting attacks on a large scale graph The original implementation with TensorFlow 1.x is [here](https://github.com/EdisonLeeeee/SGAttack).

I've tested the code in all datasets under different settings (direct or indirect attack, poisoning or evasion attack), the method acts like `Nettack`, and the only difference is the surrogate model (GCN and SGC).  The comprehensive example is shown in [test_sga.py](https://github.com/DSE-MSU/DeepRobust/blob/master/examples/graph/test_sga.py). It is easy to use SGAttack:
```python
# Setup Surrogate model
surrogate = SGC(nfeat=features.shape[1],
                nclass=labels.max().item() + 1, K=2,
                lr=0.01, device=device).to(device)

pyg_data = Dpr2Pyg(data)
surrogate.fit(pyg_data, verbose=False)  # train with earlystopping
surrogate.test()

# Setup Attack Model
target_node = 0
assert target_node in idx_unlabeled

model = SGAttack(surrogate, attack_structure=True, device=device)
model = model.to(device)

# just like Nettack
model.attack(features, adj, labels, target_node, n_perturbations)
```

It would be appreciated if our work can be included in this project.