### PR TITLE
Fix the save path problem using `os.path.join`

### DIFF
--- a/deeprobust/image/defense/AWP.py
+++ b/deeprobust/image/defense/AWP.py
@@ -125,12 +125,12 @@ class AWP_AT(BaseDefense):
 
             if (self.save_model and epoch % self.save_per_epoch == 0):
                 if os.path.isdir(str(self.save_dir)):
-                    torch.save(self.model.state_dict(), str(self.save_dir) + self.save_name + '_epoch' + str(epoch) + '.pth')
+                    torch.save(self.model.state_dict(), os.path.join(self.save_dir, self.save_name + '_epoch' + str(epoch) + '.pth'))
                     print("model saved in " + str(self.save_dir))
                 else:
                     print("make new directory and save model in " + str(self.save_dir))
                     os.mkdir('./' + str(self.save_dir))
-                    torch.save(self.model.state_dict(), str(self.save_dir) + self.save_name + '_epoch' + str(epoch) + '.pth')
+                    torch.save(self.model.state_dict(), os.path.join(self.save_dir,self.save_name + '_epoch' + str(epoch) + '.pth'))
 
             scheduler.step()
 

--- a/deeprobust/image/defense/AWP.py
+++ b/deeprobust/image/defense/AWP.py
@@ -130,7 +130,7 @@ class AWP_AT(BaseDefense):
                 else:
                     print("make new directory and save model in " + str(self.save_dir))
                     os.mkdir('./' + str(self.save_dir))
-                    torch.save(self.model.state_dict(), os.path.join(self.save_dir,self.save_name + '_epoch' + str(epoch) + '.pth'))
+                    torch.save(self.model.state_dict(), os.path.join(self.save_dir, self.save_name + '_epoch' + str(epoch) + '.pth'))
 
             scheduler.step()
 

--- a/deeprobust/image/defense/fast.py
+++ b/deeprobust/image/defense/fast.py
@@ -47,12 +47,12 @@ class Fast(BaseDefense):
 
             if (self.save_model):
                 if os.path.isdir('./' + self.save_dir):
-                    torch.save(self.model.state_dict(), './' + self.save_dir + "/" + self.save_name)
+                    torch.save(self.model.state_dict(), os.path.join(self.save_dir, self.save_name))
                     print("model saved in " + './' + self.save_dir)
                 else:
                     print("make new directory and save model in " + './' + self.save_dir)
                     os.mkdir('./' + self.save_dir)
-                    torch.save(self.model.state_dict(), './' + self.save_dir +"/" + self.save_name)
+                    torch.save(self.model.state_dict(), os.path.join(self.save_dir, self.save_name))
 
         return self.model
 

--- a/deeprobust/image/defense/fgsmtraining.py
+++ b/deeprobust/image/defense/fgsmtraining.py
@@ -60,12 +60,12 @@ class FGSMtraining(BaseDefense):
 
             if (self.save_model):
                 if os.path.isdir('./' + self.save_dir):
-                    torch.save(self.model.state_dict(), './' + self.save_dir + "/" + self.save_name)
+                    torch.save(self.model.state_dict(), os.path.join(self.save_dir, self.save_name))
                     print("model saved in " + './' + self.save_dir)
                 else:
                     print("make new directory and save model in " + './' + self.save_dir)
                     os.mkdir('./' + self.save_dir)
-                    torch.save(self.model.state_dict(), './' + self.save_dir +"/" + self.save_name)
+                    torch.save(self.model.state_dict(), os.path.join(self.save_dir, self.save_name))
 
         return self.model
 

--- a/deeprobust/image/defense/pgdtraining.py
+++ b/deeprobust/image/defense/pgdtraining.py
@@ -63,12 +63,12 @@ class PGDtraining(BaseDefense):
 
             if (self.save_model and epoch % self.save_per_epoch == 0):
                 if os.path.isdir(str(self.save_dir)):
-                    torch.save(self.model.state_dict(), str(self.save_dir) + self.save_name + '_epoch' + str(epoch) + '.pth')
+                    torch.save(self.model.state_dict(), os.path.join(self.save_dir, self.save_name + '_epoch' + str(epoch) + '.pth'))
                     print("model saved in " + str(self.save_dir))
                 else:
                     print("make new directory and save model in " + str(self.save_dir))
                     os.mkdir('./' + str(self.save_dir))
-                    torch.save(self.model.state_dict(), str(self.save_dir) + self.save_name + '_epoch' + str(epoch) + '.pth')
+                    torch.save(self.model.state_dict(), os.path.join(self.save_dir, self.save_name + '_epoch' + str(epoch) + '.pth'))
 
             scheduler.step()
 

--- a/deeprobust/image/netmodels/train_model.py
+++ b/deeprobust/image/netmodels/train_model.py
@@ -91,11 +91,11 @@ def train(model, data, device, maxepoch, data_path = './', save_per_epoch = 10, 
         if (save_model and (epoch % (save_per_epoch) == 0 or epoch == maxepoch)):
             if os.path.isdir('./trained_models/'):
                 print('Save model.')
-                torch.save(train_net.state_dict(), './trained_models/'+ data + "_" + model + "_epoch_" + str(epoch) + ".pt")
+                torch.save(train_net.state_dict(), os.path.join('trained_models', data + "_" + model + "_epoch_" + str(epoch) + ".pt"))
             else:
                 os.mkdir('./trained_models/')
                 print('Make directory and save model.')
-                torch.save(train_net.state_dict(), './trained_models/'+ data + "_" + model + "_epoch_" + str(epoch) + ".pt")
+                torch.save(train_net.state_dict(), os.path.join('trained_models', data + "_" + model + "_epoch_" + str(epoch) + ".pt"))
         scheduler.step()
 
 def feed_dataset(data, data_dict):


### PR DESCRIPTION
In `deeprobust/image/defense/pgdtraining.py` `troch.save()`, there is a problem with the save path splicing, because the default value of `save_dir` does not have '/' at the end. So I use `os.path.join` to fix the path splicing process. Also, I have applied this approach to other torch.save().